### PR TITLE
Feat[#6]: implement persistent timer state across browser restarts

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -13,7 +13,7 @@
         <div class="progress-container">
           <div class="progress-label">
             <span>Elapsed</span>
-            <span id="elapsed">--:--</span>
+            <span id="elapsed">00:00</span>
           </div>
           <div class="progress-bar">
             <div class="progress" id="elapsed-progress"></div>

--- a/popup.js
+++ b/popup.js
@@ -98,7 +98,7 @@ function handleReset() {
     clearInterval(elapsedInterval);
     clearInterval(delayInterval);
     updateDelayDisplay(0);
-    document.getElementById('elapsed').textContent = '--:--';
+    document.getElementById('elapsed').textContent = '00:00';
     document.getElementById('elapsed-progress').style.width = '0%';
     document.getElementById('delay-progress').style.width = '0%';
 }
@@ -185,13 +185,15 @@ function formatTime(seconds) {
 }
 
 function updateDelayDisplay(delaySeconds) {
+    // 딜레이가 0이거나 undefined일 때는 '00:00' 표시
     const delayText = delaySeconds > 0 ? `+${formatTime(delaySeconds)}` : '00:00';
     document.getElementById('delay').textContent = delayText;
 
     // 딜레이 프로그레스 바 업데이트
     chrome.storage.local.get(['targetMinutes'], (result) => {
         const targetSeconds = (result.targetMinutes || 30) * 60;
-        const progress = Math.min((delaySeconds / targetSeconds) * 100, 100);
+        // 딜레이가 0이면 프로그레스바도 0
+        const progress = delaySeconds > 0 ? Math.min((delaySeconds / targetSeconds) * 100, 100) : 0;
         document.getElementById('delay-progress').style.width = `${progress}%`;
     });
 }
@@ -231,7 +233,7 @@ function initializeTimerState() {
                 document.getElementById('delay').textContent = delay > 0 ? `+${formatTime(delay)}` : '00:00';
             });
         } else {
-            document.getElementById('elapsed').textContent = '--:--';
+            document.getElementById('elapsed').textContent = '00:00';
             document.getElementById('elapsed-progress').style.width = '0%';
             document.getElementById('delay-progress').style.width = '0%';
         }

--- a/styles.css
+++ b/styles.css
@@ -125,6 +125,7 @@ input[type="number"]:focus {
   flex-direction: row;
   justify-content: center;
   gap: 12px;
+  margin-bottom: 24px;  /* 버튼 그룹 아래 여백 추가 */
 }
 
 button {


### PR DESCRIPTION
## 📌 Summary

Add persistent storage support to ensure the timer state (running, paused, target time, start time) is preserved even after browser restarts.

---

## ✅ Changes

- [x] Store `isRunning`, `startTime`, `pausedTime` in `chrome.storage.local`
- [x] Restore timer state on background script initialization
- [x] Maintain pause/resume behavior with accurate elapsed tracking
- [x] Preserve target time setting between sessions

---

## 🔗 Related Issue

Closes #6

---

## 💬 Additional Notes

This allows the timer to continue working reliably even if Chrome is closed and reopened.  
Supports future features like synced UI state and more accurate delay tracking across sessions.
