### PR TITLE
Fix[#6]: Fix preset storage and validation

### DIFF
--- a/background.js
+++ b/background.js
@@ -54,16 +54,13 @@ function saveState() {
 function startTimer(targetMinutes = null) {
     if (timerState.isRunning) return;
 
-    if (targetMinutes !== null) {
-        timerState.activeTargetMinutes = targetMinutes;
-    }
-
     if (timerState.pausedTime) {
         // 일시정지 상태에서 재시작
         timerState.startTime += Date.now() - timerState.pausedTime;
         timerState.pausedTime = null;
-    } else {
+    } else if (targetMinutes !== null) {
         // 새 타이머 시작
+        timerState.activeTargetMinutes = targetMinutes; // 리셋 후 실행 시 targetTime 값 사용
         timerState.startTime = Date.now();
     }
 
@@ -86,7 +83,7 @@ function resetTimer() {
     timerState.isRunning = false;
     timerState.startTime = null;
     timerState.pausedTime = null;
-    timerState.activeTargetMinutes = 30;
+    timerState.activeTargetMinutes = 30; // 기본값으로 초기화
     clearInterval(timerState.intervalId);
     chrome.action.setBadgeText({ text: "" });
     saveState();

--- a/background.js
+++ b/background.js
@@ -6,7 +6,8 @@ self.addEventListener('activate', (event) => {
 const timerState = {
     startTime: null,
     isRunning: false,
-    pausedTime: 0,
+    pausedTime: null,
+    activeTargetMinutes: 30, // 실행 중인 타이머의 목표 시간
     intervalId: null
 };
 
@@ -20,18 +21,20 @@ async function loadState() {
             'isRunning',
             'startTime',
             'pausedTime',
-            'targetMinutes'
+            'activeTargetMinutes'
         ]);
 
         if (state.isRunning && state.startTime) {
             timerState.startTime = state.startTime;
             timerState.isRunning = true;
-            timerState.pausedTime = 0;
+            timerState.pausedTime = null;
+            timerState.activeTargetMinutes = state.activeTargetMinutes || 30;
             startTimer(true); // true: 저장된 상태에서 시작
         } else if (state.pausedTime) {
             timerState.startTime = state.startTime;
             timerState.pausedTime = state.pausedTime;
             timerState.isRunning = false;
+            timerState.activeTargetMinutes = state.activeTargetMinutes || 30;
         }
     } catch (error) {
         console.error('Failed to load state:', error);
@@ -40,94 +43,101 @@ async function loadState() {
 }
 
 function saveState() {
-    const state = {
+    chrome.storage.local.set({
         isRunning: timerState.isRunning,
         startTime: timerState.startTime,
         pausedTime: timerState.pausedTime,
-        // 타이머 상태와 함께 targetMinutes도 저장
-        targetMinutes: timerState.targetMinutes
-    };
-    chrome.storage.local.set(state);
+        activeTargetMinutes: timerState.activeTargetMinutes
+    });
 }
 
-function startTimer(fromSavedState = false) {
+function startTimer(targetMinutes = null) {
     if (timerState.isRunning) return;
-    
-    timerState.isRunning = true;
-    if (!fromSavedState) {
-        // 이미 저장된 pausedTime이 있다면 그만큼 시작 시간을 조정
-        if (timerState.pausedTime > 0) {
-            timerState.startTime = Date.now() - timerState.pausedTime;
-        } else {
-            timerState.startTime = Date.now();
-        }
-        chrome.storage.local.set({ delaySeconds: 0 });
+
+    if (targetMinutes !== null) {
+        timerState.activeTargetMinutes = targetMinutes;
     }
-    
+
+    if (timerState.pausedTime) {
+        // 일시정지 상태에서 재시작
+        timerState.startTime += Date.now() - timerState.pausedTime;
+        timerState.pausedTime = null;
+    } else {
+        // 새 타이머 시작
+        timerState.startTime = Date.now();
+    }
+
+    timerState.isRunning = true;
     saveState();
 
-    timerState.intervalId = setInterval(() => {
-        chrome.storage.local.get(['targetMinutes'], (result) => {
-            const targetMinutes = result.targetMinutes || 30;
-            const targetSeconds = targetMinutes * 60;
-            const elapsed = Math.floor((Date.now() - timerState.startTime) / 1000);
-            const remaining = targetSeconds - elapsed;
-
-            let badgeText = '';
-            let badgeColor = '#4688F1';
-
-            if (remaining >= 0) {
-                if (remaining >= 60) {
-                    badgeText = `${Math.ceil(remaining / 60)}m`;
-                } else {
-                    badgeText = `${remaining}s`;
-                }
-            } else {
-                const delaySeconds = Math.abs(remaining);
-                badgeColor = '#E74C3C';
-
-                if (delaySeconds >= 60) {
-                    badgeText = `+${Math.floor(delaySeconds / 60)}m`;
-                } else {
-                    badgeText = `+${delaySeconds}s`;
-                }
-                // 딜레이가 있을 때만 delaySeconds 업데이트
-                chrome.storage.local.set({ delaySeconds });
-            }
-
-            chrome.action.setBadgeText({ text: badgeText });
-            chrome.action.setBadgeBackgroundColor({ color: badgeColor });
-        });
-    }, 1000);
+    timerState.intervalId = setInterval(updateBadge, 1000);
 }
 
 function pauseTimer() {
     if (!timerState.isRunning) return;
+
     timerState.isRunning = false;
+    timerState.pausedTime = Date.now();
     clearInterval(timerState.intervalId);
-    timerState.pausedTime = Date.now() - timerState.startTime;
     saveState();
 }
 
 function resetTimer() {
     timerState.isRunning = false;
     timerState.startTime = null;
-    timerState.pausedTime = 0;
+    timerState.pausedTime = null;
+    timerState.activeTargetMinutes = 30;
     clearInterval(timerState.intervalId);
     chrome.action.setBadgeText({ text: "" });
     saveState();
 }
 
+function updateBadge() {
+    const now = Date.now();
+    const elapsed = Math.floor((now - timerState.startTime) / 1000);
+    const targetSeconds = timerState.activeTargetMinutes * 60;
+    const remaining = targetSeconds - elapsed;
+
+    let badgeText = '';
+    let badgeColor = '#4688F1';
+
+    if (remaining >= 0) {
+        badgeText = remaining >= 60 ? `${Math.ceil(remaining / 60)}m` : `${Math.ceil(remaining)}s`; // 반올림
+    } else {
+        const delaySeconds = Math.abs(remaining);
+        badgeText = delaySeconds >= 60 ? `+${Math.ceil(delaySeconds / 60)}m` : `+${Math.ceil(delaySeconds)}s`; // 반올림
+        badgeColor = '#E74C3C';
+    }
+
+    chrome.action.setBadgeText({ text: badgeText });
+    chrome.action.setBadgeBackgroundColor({ color: badgeColor });
+}
+
 // 메시지 수신 처리
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-    if (message.action === 'startTimer') startTimer();
-    else if (message.action === 'pauseTimer') pauseTimer();
-    else if (message.action === 'resetTimer') resetTimer();
-    else if (message.action === 'getStatus') {
+    if (message.action === 'startTimer') {
+        startTimer(message.targetMinutes);
+    } else if (message.action === 'pauseTimer') {
+        pauseTimer();
+    } else if (message.action === 'resetTimer') {
+        resetTimer();
+    } else if (message.action === 'getStatus') {
+        const now = Date.now();
+        let elapsed = 0;
+        if (timerState.startTime) {
+            elapsed = Math.floor((timerState.pausedTime || now) - timerState.startTime) / 1000;
+        }
+        const targetSeconds = timerState.activeTargetMinutes * 60;
+        const remaining = Math.max(Math.ceil(targetSeconds - elapsed), 0); // 반올림
+        const delay = Math.max(Math.ceil(elapsed - targetSeconds), 0); // 반올림
+
         sendResponse({
             isRunning: timerState.isRunning,
             startTime: timerState.startTime,
-            pausedTime: !timerState.isRunning && timerState.startTime ? Date.now() - timerState.startTime : null
+            pausedTime: timerState.pausedTime,
+            activeTargetMinutes: timerState.activeTargetMinutes,
+            remaining,
+            delay
         });
     }
     return true; // sendResponse 비동기 응답을 위해 필요

--- a/popup.html
+++ b/popup.html
@@ -14,7 +14,7 @@
           <div class="progress-label">
             <span>Remaining</span>
             <div class="time-display">
-              <span id="elapsed">00:00</span>
+              <span id="elapsed">00:00</span> <!-- 초기값을 00:00으로 설정 -->
               <span class="time-separator">/</span>
               <span id="total-time" class="total-time">30:00</span>
             </div>

--- a/popup.html
+++ b/popup.html
@@ -12,8 +12,12 @@
         <i class="bi bi-stopwatch"></i>
         <div class="progress-container">
           <div class="progress-label">
-            <span>Elapsed</span>
-            <span id="elapsed">00:00</span>
+            <span>Remaining</span>
+            <div class="time-display">
+              <span id="elapsed">00:00</span>
+              <span class="time-separator">/</span>
+              <span id="total-time" class="total-time">30:00</span>
+            </div>
           </div>
           <div class="progress-bar">
             <div class="progress" id="elapsed-progress"></div>
@@ -25,7 +29,9 @@
         <div class="progress-container">
           <div class="progress-label">
             <span>Delay</span>
-            <span id="delay">0s</span>
+            <div class="time-display">
+              <span id="delay" class="delay-time">00:00</span>
+            </div>
           </div>
           <div class="progress-bar">
             <div class="progress" id="delay-progress"></div>

--- a/popup.js
+++ b/popup.js
@@ -8,9 +8,12 @@ let timerState = {
 
 document.addEventListener('DOMContentLoaded', async () => {
     try {
-        const result = await chrome.storage.local.get(['targetMinutes']);
+        const result = await chrome.storage.local.get(['targetMinutes', 'presets']);
         timerState.targetMinutes = result.targetMinutes || 30;
         document.getElementById('targetTime').value = timerState.targetMinutes;
+
+        const presets = result.presets || [30, 40, 60];
+        updatePresetButtons(presets);
 
         setupEventListeners();
         initializeTimerState();
@@ -24,6 +27,19 @@ function setupEventListeners() {
     document.getElementById('start').addEventListener('click', handleStart);
     document.getElementById('pause').addEventListener('click', handlePause);
     document.getElementById('reset').addEventListener('click', handleReset);
+
+    // 프리셋 버튼 클릭 이벤트 추가
+    document.querySelectorAll('.preset-btn').forEach(button => {
+        button.addEventListener('click', handlePresetClick);
+    });
+
+    // 설정 버튼 클릭 이벤트 추가
+    document.querySelector('.settings-btn').addEventListener('click', openPresetModal);
+
+    // 모달 닫기 및 저장 버튼 이벤트 추가
+    document.getElementById('cancelPresets').addEventListener('click', closePresetModal);
+    document.getElementById('savePresets').addEventListener('click', savePresetChanges);
+    document.querySelector('.close-btn').addEventListener('click', closePresetModal);
 }
 
 function handleTargetTimeChange(e) {
@@ -35,10 +51,25 @@ function handleTargetTimeChange(e) {
 }
 
 function handleStart() {
-    chrome.runtime.sendMessage({
-        action: 'startTimer',
-        targetMinutes: timerState.targetMinutes
-    });
+    const targetMinutes = timerState.isRunning || timerState.pausedTime
+        ? timerState.activeTargetMinutes // 기존 값을 유지
+        : parseInt(document.getElementById('targetTime').value, 10); // 리셋 후 targetTime 값 사용
+
+    if (!isNaN(targetMinutes) && targetMinutes > 0) {
+        if (!timerState.isRunning && !timerState.pausedTime) {
+            // 리셋 후 처음 실행 시 targetTime 값을 activeTargetMinutes에 설정
+            timerState.activeTargetMinutes = targetMinutes;
+        }
+
+        chrome.runtime.sendMessage({
+            action: 'startTimer',
+            targetMinutes: timerState.activeTargetMinutes // 항상 activeTargetMinutes 사용
+        });
+
+        // total-time을 activeTargetMinutes 값으로 업데이트
+        const targetSeconds = timerState.activeTargetMinutes * 60;
+        document.getElementById('total-time').textContent = formatTime(targetSeconds);
+    }
 }
 
 function handlePause() {
@@ -47,15 +78,28 @@ function handlePause() {
 
 function handleReset() {
     chrome.runtime.sendMessage({ action: 'resetTimer' });
+    timerState.startTime = null;
+    timerState.isRunning = false;
+    timerState.pausedTime = null;
+    timerState.activeTargetMinutes = timerState.targetMinutes; // targetTime 값으로 초기화
     resetUI();
 }
 
+function handlePresetClick(e) {
+    const time = parseInt(e.target.dataset.time, 10);
+    if (!isNaN(time) && time > 0) {
+        timerState.targetMinutes = time;
+        document.getElementById('targetTime').value = time; // 입력 필드에 반영
+        chrome.storage.local.set({ targetMinutes: time });
+    }
+}
+
 function resetUI() {
-    const targetSeconds = timerState.activeTargetMinutes * 60;
-    updateUIFromStatus(targetSeconds, 0, targetSeconds);
+    const totalSeconds = timerState.activeTargetMinutes * 60; // 현재 설정된 총 시간
+    updateUIFromStatus(0, 0, totalSeconds); // remaining time을 0으로 설정
     document.getElementById('elapsed-progress').style.width = '0%';
     document.getElementById('delay-progress').style.width = '0%';
-    document.getElementById('total-time').textContent = formatTime(timerState.activeTargetMinutes * 60);
+    document.getElementById('total-time').textContent = formatTime(totalSeconds);
 }
 
 function initializeTimerState() {
@@ -70,9 +114,12 @@ function initializeTimerState() {
 
             if (timerState.isRunning) {
                 startStatusUpdateInterval();
-            } else {
-                // 일시정지 상태 또는 초기 상태
+            } else if (timerState.pausedTime) {
+                // 일시정지 상태에서는 최신 remaining, delay 값을 유지
                 updateUIFromStatus(res.remaining, res.delay, targetSeconds);
+            } else {
+                // 초기 상태
+                updateUIFromStatus(0, 0, targetSeconds);
             }
 
             // Update total time display
@@ -95,13 +142,15 @@ function startStatusUpdateInterval() {
 }
 
 function updateUIFromStatus(remaining, delay, targetSeconds) {
+    const totalSeconds = timerState.activeTargetMinutes * 60; // 현재 설정된 총 시간
     document.getElementById('elapsed').textContent = formatTime(remaining);
     document.getElementById('delay').textContent = delay > 0 ? `+${formatTime(delay)}` : '00:00';
 
-    const progress = Math.max((remaining / targetSeconds) * 100, 0);
+    // 프로그래스 바 계산을 총 시간 기준으로 변경
+    const progress = Math.max((remaining / totalSeconds) * 100, 0);
     document.getElementById('elapsed-progress').style.width = `${Math.floor(progress)}%`;
 
-    const delayProgress = Math.min((delay / targetSeconds) * 100, 100);
+    const delayProgress = Math.min((delay / totalSeconds) * 100, 100);
     document.getElementById('delay-progress').style.width = `${Math.floor(delayProgress)}%`;
 }
 
@@ -145,4 +194,44 @@ function formatTime(seconds) {
     const min = Math.floor(seconds / 60);
     const sec = seconds % 60;
     return `${String(min).padStart(2, '0')}:${String(sec).padStart(2, '0')}`;
+}
+
+function openPresetModal() {
+    chrome.storage.local.get(['presets'], (result) => {
+        const presets = result.presets || [30, 40, 60];
+        document.getElementById('preset1').value = presets[0];
+        document.getElementById('preset2').value = presets[1];
+        document.getElementById('preset3').value = presets[2];
+    });
+    document.getElementById('presetModal').classList.add('show');
+}
+
+function closePresetModal() {
+    document.getElementById('presetModal').classList.remove('show');
+}
+
+function savePresetChanges() {
+    const presets = [
+        parseInt(document.getElementById('preset1').value, 10),
+        parseInt(document.getElementById('preset2').value, 10),
+        parseInt(document.getElementById('preset3').value, 10)
+    ].filter(val => !isNaN(val) && val > 0);
+
+    if (presets.length === 3) {
+        // 크롬 스토리지에 프리셋 저장
+        chrome.storage.local.set({ presets }, () => {
+            updatePresetButtons(presets); // 버튼 업데이트
+            closePresetModal(); // 모달 닫기
+        });
+    } else {
+        alert('Please enter valid preset values (greater than 0).');
+    }
+}
+
+function updatePresetButtons(presets) {
+    const buttons = document.querySelectorAll('.preset-btn');
+    buttons.forEach((button, index) => {
+        button.textContent = `${presets[index]}m`;
+        button.dataset.time = presets[index];
+    });
 }

--- a/popup.js
+++ b/popup.js
@@ -1,35 +1,18 @@
-// 전역 상태 보완
 let timerState = {
     targetMinutes: 30,
     startTime: null,
-    pauseStartTime: null,
-    totalPauseDuration: 0,
-    elapsedInterval: null,
-    delayInterval: null,
-    activeTargetMinutes: 30  // 현재 실행 중인 타이머의 목표 시간
+    isRunning: false,
+    pausedTime: null,
+    activeTargetMinutes: 30
 };
 
 document.addEventListener('DOMContentLoaded', async () => {
     try {
-        // 초기 상태 로드
-        const targetTimeInput = document.getElementById('targetTime');
         const result = await chrome.storage.local.get(['targetMinutes']);
         timerState.targetMinutes = result.targetMinutes || 30;
-        if (targetTimeInput) {
-            targetTimeInput.value = result.targetMinutes || 30;
-            // 초기 total time 설정
-            document.getElementById('total-time').textContent = formatTime((result.targetMinutes || 30) * 60);
-        }
+        document.getElementById('targetTime').value = timerState.targetMinutes;
 
-        // delay 시간 불러오기
-        const delayResult = await chrome.storage.local.get(['delaySeconds']);
-        const delay = delayResult.delaySeconds || 0;
-        updateDelayDisplay(delay);
-
-        // 이벤트 리스너 설정
         setupEventListeners();
-        
-        // 초기 상태 확인 및 업데이트
         initializeTimerState();
     } catch (error) {
         console.error('Initialization error:', error);
@@ -37,257 +20,129 @@ document.addEventListener('DOMContentLoaded', async () => {
 });
 
 function setupEventListeners() {
-    const elements = {
-        targetTime: document.getElementById('targetTime'),
-        start: document.getElementById('start'),
-        pause: document.getElementById('pause'),
-        reset: document.getElementById('reset'),
-        settingsBtn: document.querySelector('.settings-btn'),
-        closeBtn: document.querySelector('.close-btn'),
-        cancelPresets: document.getElementById('cancelPresets'),
-        savePresets: document.getElementById('savePresets')
-    };
-
-    // 각 요소가 존재하는지 확인 후 이벤트 리스너 추가
-    if (elements.targetTime) {
-        elements.targetTime.addEventListener('input', handleTargetTimeChange);
-    }
-
-    if (elements.start) {
-        elements.start.addEventListener('click', handleStart);
-    }
-
-    if (elements.pause) {
-        elements.pause.addEventListener('click', handlePause);
-    }
-
-    if (elements.reset) {
-        elements.reset.addEventListener('click', handleReset);
-    }
-
-    if (elements.settingsBtn) {
-        elements.settingsBtn.addEventListener('click', handleSettings);
-    }
-
-    if (elements.closeBtn) {
-        elements.closeBtn.addEventListener('click', closeModal);
-    }
-
-    if (elements.cancelPresets) {
-        elements.cancelPresets.addEventListener('click', closeModal);
-    }
-
-    if (elements.savePresets) {
-        elements.savePresets.addEventListener('click', handleSavePresets);
-    }
-
-    document.querySelectorAll('.preset-btn').forEach(btn => {
-        btn.addEventListener('click', handlePresetClick);
-    });
+    document.getElementById('targetTime').addEventListener('input', handleTargetTimeChange);
+    document.getElementById('start').addEventListener('click', handleStart);
+    document.getElementById('pause').addEventListener('click', handlePause);
+    document.getElementById('reset').addEventListener('click', handleReset);
 }
 
 function handleTargetTimeChange(e) {
     const value = parseInt(e.target.value, 10);
     if (!isNaN(value) && value > 0) {
-        // 값을 저장하되 실행 중인 타이머에는 영향을 주지 않음
         timerState.targetMinutes = value;
         chrome.storage.local.set({ targetMinutes: value });
-        
-        // 타이머가 실행 중이지 않을 때만 total-time 업데이트
-        if (!timerState.startTime) {
-            document.getElementById('total-time').textContent = formatTime(value * 60);
-        }
     }
 }
 
 function handleStart() {
-    const now = Date.now();
-    
-    if (timerState.pauseStartTime) {
-        // 일시정지 상태에서 재시작하는 경우
-        timerState.totalPauseDuration += (now - timerState.pauseStartTime);
-        timerState.pauseStartTime = null;
-    } else if (!timerState.startTime) {
-        // 처음 시작하는 경우
-        timerState.startTime = now;
-        timerState.totalPauseDuration = 0;
-        // 시작할 때 현재 설정된 목표 시간을 활성 목표 시간으로 설정
-        timerState.activeTargetMinutes = timerState.targetMinutes;
-        document.getElementById('total-time').textContent = formatTime(timerState.activeTargetMinutes * 60);
-    }
-
-    updateElapsed(now);
-    startDelayUpdate();
-    chrome.runtime.sendMessage({ action: 'startTimer' });
+    chrome.runtime.sendMessage({
+        action: 'startTimer',
+        targetMinutes: timerState.targetMinutes
+    });
 }
-
-// 전역 변수로 일시정지 시간 추적
-let timerPausedDuration = 0;
-let pausedTime = null;
 
 function handlePause() {
     chrome.runtime.sendMessage({ action: 'pauseTimer' });
-    clearInterval(timerState.elapsedInterval);
-    clearInterval(timerState.delayInterval);
-    timerState.pauseStartTime = Date.now();
 }
 
 function handleReset() {
     chrome.runtime.sendMessage({ action: 'resetTimer' });
-    clearInterval(timerState.elapsedInterval);
-    clearInterval(timerState.delayInterval);
-    timerState = {
-        ...timerState,
-        startTime: null,
-        pauseStartTime: null,
-        totalPauseDuration: 0
-    };
-    timerState.activeTargetMinutes = timerState.targetMinutes;  // 리셋 시 목표 시간 동기화
-    document.getElementById('total-time').textContent = formatTime(timerState.targetMinutes * 60);
-    updateDelayDisplay(0);
-    document.getElementById('elapsed').textContent = '00:00';
+    resetUI();
+}
+
+function resetUI() {
+    const targetSeconds = timerState.activeTargetMinutes * 60;
+    updateUIFromStatus(targetSeconds, 0, targetSeconds);
     document.getElementById('elapsed-progress').style.width = '0%';
     document.getElementById('delay-progress').style.width = '0%';
+    document.getElementById('total-time').textContent = formatTime(timerState.activeTargetMinutes * 60);
 }
 
-function handleSettings() {
-    chrome.storage.local.get(['presets'], (result) => {
-        const presets = result.presets || [30, 40, 60];
-        document.getElementById('preset1').value = presets[0];
-        document.getElementById('preset2').value = presets[1];
-        document.getElementById('preset3').value = presets[2];
-    });
-    document.getElementById('presetModal').classList.add('show');
-}
-
-function handleSavePresets() {
-    const presets = [
-        parseInt(document.getElementById('preset1').value),
-        parseInt(document.getElementById('preset2').value),
-        parseInt(document.getElementById('preset3').value)
-    ].filter(val => !isNaN(val) && val > 0);
-
-    if (presets.length === 3) {
-        chrome.storage.local.set({ presets }, () => {
-            updatePresetButtons(presets);
-            closeModal();
-        });
-    }
-}
-
-function handlePresetClick() {
-    const time = this.dataset.time;
-    document.getElementById('targetTime').value = time;
-    // 프리셋 버튼 클릭 시에도 total time은 업데이트하지 않고 저장만 함
-    chrome.storage.local.set({ targetMinutes: parseInt(time, 10) });
-
-    // Remove active class from all preset buttons
-    document.querySelectorAll('.preset-btn').forEach(b => b.classList.remove('active'));
-    // Add active class to clicked button
-    this.classList.add('active');
-}
-
-function closeModal() {
-    document.getElementById('presetModal').classList.remove('show');
-}
-
-function updatePresetButtons(presets) {
-    const buttons = document.querySelectorAll('.preset-btn');
-    buttons.forEach((btn, index) => {
-        btn.dataset.time = presets[index];
-        btn.textContent = `${presets[index]}m`;
-    });
-}
-
-function updateElapsed(now) {
-    clearInterval(timerState.elapsedInterval);
-
-    function update() {
-        const currentTime = Date.now();
-        const effectiveElapsed = currentTime - timerState.startTime - timerState.totalPauseDuration;
-        const elapsedSec = Math.floor(effectiveElapsed / 1000);
-        // 활성 목표 시간 사용
-        const targetSeconds = timerState.activeTargetMinutes * 60;
-        const remainingSec = Math.max(targetSeconds - elapsedSec, 0);
-        
-        document.getElementById('elapsed').textContent = formatTime(remainingSec);
-        const progress = Math.max((remainingSec / targetSeconds) * 100, 0);
-        document.getElementById('elapsed-progress').style.width = `${progress}%`;
-    }
-
-    update();
-    timerState.elapsedInterval = setInterval(update, 1000);
-}
-
-function formatTime(seconds) {
-    const min = Math.floor(seconds / 60);
-    const sec = seconds % 60;
-    return `${String(min).padStart(2, '0')}:${String(sec).padStart(2, '0')}`;
-}
-
-function updateDelayDisplay(delaySeconds) {
-    const delayEl = document.getElementById('delay');
-    const delayText = delaySeconds > 0 ? `+${formatTime(delaySeconds)}` : '00:00';
-    delayEl.textContent = delayText;
-    delayEl.classList.toggle('delayed', delaySeconds > 0);
-
-    chrome.storage.local.get(['targetMinutes'], (result) => {
-        const targetSeconds = (result.targetMinutes || 30) * 60;
-        // 딜레이는 왼쪽에서 오른쪽으로 증가
-        const progress = delaySeconds > 0 ? Math.min((delaySeconds / targetSeconds) * 100, 100) : 0;
-        document.getElementById('delay-progress').style.width = `${progress}%`;
-    });
-}
-
-// 딜레이 업데이트를 위한 인터벌 설정
-let delayInterval = null;
-
-function startDelayUpdate() {
-    clearInterval(timerState.delayInterval);
-    timerState.delayInterval = setInterval(() => {
-        chrome.storage.local.get(['delaySeconds'], (result) => {
-            updateDelayDisplay(result.delaySeconds || 0);
-        });
-    }, 1000);
-}
-
-// 초기 상태 확인 및 업데이트 시작
 function initializeTimerState() {
     chrome.runtime.sendMessage({ action: 'getStatus' }, (res) => {
-        if (res?.isRunning && res?.startTime) {
+        if (res) {
             timerState.startTime = res.startTime;
-            // activeTargetMinutes 복원
-            chrome.storage.local.get(['targetMinutes'], (result) => {
-                timerState.activeTargetMinutes = result.targetMinutes || 30;
-                updateElapsed(Date.now());
-                startDelayUpdate();
-            });
-        } else if (res?.pausedTime) {
-            // 일시 정지 상태일 때는 마지막 시간을 표시
-            const elapsedSec = Math.floor((res.pausedTime) / 1000);
-            chrome.storage.local.get(['targetMinutes', 'delaySeconds'], (result) => {
-                timerState.activeTargetMinutes = result.targetMinutes || 30;
-                const targetSeconds = timerState.activeTargetMinutes * 60;
-                document.getElementById('elapsed').textContent = formatTime(Math.max(targetSeconds - elapsedSec, 0));
-                document.getElementById('total-time').textContent = formatTime(targetSeconds);
+            timerState.isRunning = res.isRunning;
+            timerState.pausedTime = res.pausedTime;
+            timerState.activeTargetMinutes = res.activeTargetMinutes;
 
-                const elapsedProgress = Math.min((elapsedSec / targetSeconds) * 100, 100);
-                document.getElementById('elapsed-progress').style.width = `${Math.max(100 - elapsedProgress, 0)}%`;
+            const targetSeconds = timerState.activeTargetMinutes * 60;
 
-                const delay = result.delaySeconds || 0;
-                const delayProgress = Math.min((delay / targetSeconds) * 100, 100);
-                document.getElementById('delay-progress').style.width = `${delayProgress}%`;
-                document.getElementById('delay').textContent = delay > 0 ? `+${formatTime(delay)}` : '00:00';
-            });
+            if (timerState.isRunning) {
+                startStatusUpdateInterval();
+            } else {
+                // 일시정지 상태 또는 초기 상태
+                updateUIFromStatus(res.remaining, res.delay, targetSeconds);
+            }
+
+            // Update total time display
+            document.getElementById('total-time').textContent = formatTime(targetSeconds);
         }
     });
 }
 
-// 메시지 리스너 추가
-chrome.runtime.onMessage.addListener((message) => {
-    if (message.action === 'timerStarted') {
-        timerState.startTime = message.startTime;
-        updateElapsed(Date.now());
-        startDelayUpdate();
-    }
-});
+function startStatusUpdateInterval() {
+    clearInterval(timerState.elapsedInterval);
+
+    timerState.elapsedInterval = setInterval(() => {
+        chrome.runtime.sendMessage({ action: 'getStatus' }, (res) => {
+            if (res) {
+                const targetSeconds = timerState.activeTargetMinutes * 60;
+                updateUIFromStatus(res.remaining, res.delay, targetSeconds);
+            }
+        });
+    }, 1000);
+}
+
+function updateUIFromStatus(remaining, delay, targetSeconds) {
+    document.getElementById('elapsed').textContent = formatTime(remaining);
+    document.getElementById('delay').textContent = delay > 0 ? `+${formatTime(delay)}` : '00:00';
+
+    const progress = Math.max((remaining / targetSeconds) * 100, 0);
+    document.getElementById('elapsed-progress').style.width = `${Math.floor(progress)}%`;
+
+    const delayProgress = Math.min((delay / targetSeconds) * 100, 100);
+    document.getElementById('delay-progress').style.width = `${Math.floor(delayProgress)}%`;
+}
+
+function updateElapsedUI(elapsed, targetSeconds) {
+    const remaining = Math.max(targetSeconds - elapsed, 0);
+    const delay = Math.max(elapsed - targetSeconds, 0);
+
+    document.getElementById('elapsed').textContent = formatTime(remaining);
+    document.getElementById('delay').textContent = delay > 0 ? `+${formatTime(delay)}` : '00:00';
+
+    const progress = Math.max((remaining / targetSeconds) * 100, 0);
+    document.getElementById('elapsed-progress').style.width = `${progress}%`;
+
+    const delayProgress = Math.min((delay / targetSeconds) * 100, 100);
+    document.getElementById('delay-progress').style.width = `${delayProgress}%`;
+}
+
+function updateElapsed() {
+    const now = Date.now();
+    const elapsed = Math.floor((now - timerState.startTime) / 1000);
+    const targetSeconds = timerState.activeTargetMinutes * 60;
+    const remaining = Math.max(targetSeconds - elapsed, 0);
+
+    document.getElementById('elapsed').textContent = formatTime(remaining);
+    const progress = Math.max((remaining / targetSeconds) * 100, 0);
+    document.getElementById('elapsed-progress').style.width = `${progress}%`;
+}
+
+function updatePausedState() {
+    const elapsed = Math.floor((timerState.pausedTime - timerState.startTime) / 1000);
+    const targetSeconds = timerState.activeTargetMinutes * 60;
+    const remaining = Math.max(targetSeconds - elapsed, 0);
+
+    document.getElementById('elapsed').textContent = formatTime(remaining);
+    const progress = Math.max((remaining / targetSeconds) * 100, 0);
+    document.getElementById('elapsed-progress').style.width = `${progress}%`;
+}
+
+function formatTime(seconds) {
+    seconds = Math.ceil(seconds); // 반올림하여 아이콘과 동일하게 표시
+    const min = Math.floor(seconds / 60);
+    const sec = seconds % 60;
+    return `${String(min).padStart(2, '0')}:${String(sec).padStart(2, '0')}`;
+}

--- a/styles.css
+++ b/styles.css
@@ -60,9 +60,51 @@ body {
 .progress-label {
   display: flex;
   justify-content: space-between;
-  margin-bottom: 4px;
+  align-items: baseline;
+  margin-bottom: 6px;
   font-size: 12px;
   font-weight: 500;
+}
+
+.time-display {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  font-family: 'SF Mono', 'Consolas', monospace;
+  font-size: 13px;
+  font-feature-settings: "tnum";
+  letter-spacing: -0.2px;
+}
+
+#elapsed, .delay-time {
+  font-weight: 600;
+  min-width: 46px;
+  text-align: right;
+}
+
+#elapsed {
+  color: var(--primary-color);
+}
+
+.delay-time {
+  color: var(--text-secondary);
+}
+
+.delay-time.delayed {
+  color: #dc2626;
+}
+
+.time-separator {
+  color: var(--text-secondary);
+  font-weight: normal;
+  opacity: 0.5;
+  margin: 0 1px;
+}
+
+.total-time {
+  color: var(--text-secondary);
+  font-size: 12px;
+  opacity: 0.8;
 }
 
 .progress-bar {
@@ -71,6 +113,7 @@ body {
   background-color: var(--background);
   border-radius: 3px;
   overflow: hidden;
+  position: relative;
 }
 
 .progress {
@@ -83,10 +126,18 @@ body {
 
 #elapsed-progress {
   background-color: var(--primary-color);
+  position: absolute;
+  right: 0;
+  left: auto;
+  transform-origin: right;
 }
 
 #delay-progress {
   background-color: #dc2626;
+  position: absolute;
+  left: 0;
+  right: auto;
+  transform-origin: left;
 }
 
 .input-group {


### PR DESCRIPTION
## 📌 Summary

> Briefly describe what this PR does.  
> Example: Add delay time display on badge after exceeding target time



Details:
- Fixed `savePresetChanges` to correctly store presets in Chrome storage.
- Added validation for preset values to ensure they are greater than 0.
- Updated `handleStart` to maintain the latest `activeTargetMinutes` when resuming from pause.
- Modified `handleReset` to reset the timer state and use `targetTime` for new starts.
- Adjusted `resetUI` to initialize `remaining` time to `00:00` and reset progress bars.
- Enhanced `initializeTimerState` to handle paused states and retain the latest `remaining` and `delay` values.
- Updated `popup.html` to ensure consistent initial display of `remaining` and `total-time`.
- Improved `background.js` to handle paused and resumed states correctly.
- Refined progress bar calculations in `popup.js` to reflect the correct total time.
- Updated styles in `styles.css` for better UI consistency.

---

## ✅ Changes

- [x] Fix preset storage and validation
- [x] Improve start/pause/reset state transitions
- [x] Sync remaining and delay time across popup and background
- [x] Refine styles and progress bar behavior for better UI consistency

---

## 🔗 Related Issue

> Related #6 

---

## 💬 Additional Notes
